### PR TITLE
cleans up install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,9 @@ git clone https://github.com/mostjs/package-starter $name \
 && cd $name \
 && rm -rf ./.git \
 && git init \
-&& sed -i -- "s/mostPackage/${name}/g" package.json \
+&& sed -i.bak "s/mostPackage/${name}/g" package.json \
+&& rm -rf package.json.bak \
+&& rm -rf install.sh \
 && npm install 
 
 printf "\e[32m[✔] Successfully installed ${name}\e[32m!\n"


### PR DESCRIPTION
so when building my `most-file-reader` repo using the one-liner from this repo i noticed that i get
`package.json--` & `package.json` it was due to my `sed` command creating a backup file with `--`
Without the dashes it seems to have an issue (throws an error) on `Mac OSX` so i decided to use the `.bak` convention and then deleting that back up file.

I also added a `rm -rf` for the `install.sh` because it doesn't seem like package creator would need that file in their repo ?
