### PR TITLE
Add keywords and simplify build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .idea/
 coverage/
+.nyc_output/

--- a/package.json
+++ b/package.json
@@ -15,21 +15,30 @@
     "eslint-config-standard": "^6.2.1",
     "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-standard": "^2.0.1",
-    "istanbul": "^1.1.0-alpha.1",
     "jsinspect": "^0.9.0",
     "mocha": "^3.4.2",
-    "most": "^1.4.0",
+    "most": "^1.5.1",
+    "nyc": "^11.1.0",
     "rollup": "^0.41.1",
     "rollup-plugin-buble": "^0.15.0",
-    "uglify-js": "^3.0.14",
-    "umd-name-transform": "^1.0.1"
+    "uglify-js": "^3.0.14"
   },
   "files": [
     "dist/mostPackage.js"
   ],
   "homepage": "https://github.com/mostjs/mostPackage#readme",
+  "keywords": [
+    "most",
+    "mostjs",
+    "reactive",
+    "event",
+    "async",
+    "stream"
+  ],
   "license": "MIT",
-  "main": "dist/mostPackage.js",
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
+  "jsnext:main": "dist/index.es.js",
   "peerDependencies": {
     "most": "^1.0.0"
   },
@@ -38,12 +47,12 @@
     "url": "git+https://github.com/mostjs/mostPackage.git"
   },
   "scripts": {
-    "build": "npm run build-dist && uglifyjs dist/mostPackage.js -o dist/mostPackage.min.js",
-    "build-dist": "mkdir -p dist && rollup -c --name '@most/mostPackage' | umd-name-transform -o dist/mostPackage.js",
-    "lint": "jsinspect src && jsinspect test && eslint src test",
+    "build": "npm run build:dist && uglifyjs dist/index.js -o dist/index.min.js",
+    "build:dist": "mkdir -p dist && rollup -c --name 'mostPackage'",
+    "test:lint": "jsinspect src && jsinspect test && eslint src test",
     "prepublish": "npm run build",
     "preversion": "npm run build",
-    "test": "npm run lint && npm run unit-test",
-    "unit-test": "istanbul cover _mocha"
+    "test": "npm run test:lint && npm run test:unit",
+    "test:unit": "nyc mocha -r buba/register"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "uglify-js": "^3.0.14"
   },
   "files": [
-    "dist/mostPackage.js"
+    "dist"
   ],
   "homepage": "https://github.com/mostjs/mostPackage#readme",
   "keywords": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,20 @@
-import buble from 'rollup-plugin-buble';
+import buble from 'rollup-plugin-buble'
 
 export default {
   entry: 'src/index.js',
-  format: 'umd',
-  plugins: [ buble() ]
-};
+  plugins: [
+    buble()
+  ],
+  targets: [
+    {
+      dest: 'dist/index.js',
+      format: 'umd',
+      sourceMap: true
+    },
+    {
+      dest: 'dist/index.es.js',
+      format: 'es',
+      sourceMap: true
+    }
+  ]
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,0 @@
---require buba/register


### PR DESCRIPTION
This PR does a few things:

1. Add some standard keywords to package.json to facilitate npm discovery
2. Update to nyc for code coverage
3. Update build to generate UMD and ES versions, add "module" and "jsnext:main" to package.json
    - Note that this changes the default module name for UMD modules (and stops using umd-name-transform), but since we already ask folks to edit package.json and replace "mostPackage", this doesn't add any more steps for users.  IOW, they still have to edit package.json and replace "mostPackage" in several places.

### Questions

1. Are there other reasonable alternatives for the build and the UMD module name?
2. Should we stop using uglify to build minified versions?
3. Should we add dist to .gitignore?